### PR TITLE
Add Android Studio skeleton

### DIFF
--- a/android_native/README.md
+++ b/android_native/README.md
@@ -1,0 +1,9 @@
+# Android Native Port (Skeleton)
+
+Dieses Verzeichnis enthält ein grundlegendes Android-Studio-Projekt als Ausgangspunkt für die Portierung der QML/Qt-Anwendung.
+
+* `MainActivity.kt` entspricht grob dem `ApplicationWindow` aus `main.qml` und hostet die Navigation.
+* Die einzelnen Fragmente (`HomePageFragment`, `WeekViewFragment` usw.) sind Platzhalter für die jeweiligen QML-Komponenten.
+* Das Navigationsdiagramm `nav_graph.xml` spiegelt die Wechsel zwischen den Seiten wider, wie sie im QML `SwipeView` realisiert sind.
+
+Die eigentliche Logik der C++-Klassen und QML-Skripte wurde hier **nicht** übersetzt. Stattdessen dient das Projekt als Startpunkt für eine manuelle Migration nach Kotlin. Weitere Anbindung der Datenmodelle muss separat erfolgen (z.B. per LiveData oder Kotlin Coroutines).

--- a/android_native/app/build.gradle
+++ b/android_native/app/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.mealapp'
+    compileSdk 33
+
+    defaultConfig {
+        applicationId 'com.example.mealapp'
+        minSdk 21
+        targetSdk 33
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.6.0'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.6.0'
+}

--- a/android_native/app/proguard-rules.pro
+++ b/android_native/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# ProGuard rules

--- a/android_native/app/src/main/AndroidManifest.xml
+++ b/android_native/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.example.mealapp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.MealApp">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android_native/app/src/main/java/com/example/mealapp/MainActivity.kt
+++ b/android_native/app/src/main/java/com/example/mealapp/MainActivity.kt
@@ -1,0 +1,26 @@
+package com.example.mealapp
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.findNavController
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.setupActionBarWithNavController
+
+/**
+ * Entspricht dem QML ApplicationWindow aus main.qml
+ */
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        // Navigation-Host suchen (entspricht SwipeView/Navigation aus QML)
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        setupActionBarWithNavController(navHostFragment.navController)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        val navController = findNavController(R.id.nav_host_fragment)
+        return navController.navigateUp() || super.onSupportNavigateUp()
+    }
+}

--- a/android_native/app/src/main/java/com/example/mealapp/ui/HomePageFragment.kt
+++ b/android_native/app/src/main/java/com/example/mealapp/ui/HomePageFragment.kt
@@ -1,0 +1,20 @@
+package com.example.mealapp.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+/**
+ * Placeholder Fragment entspricht HomePage.qml
+ */
+class HomePageFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_homepage, container, false)
+    }
+}

--- a/android_native/app/src/main/java/com/example/mealapp/ui/MealAddFragment.kt
+++ b/android_native/app/src/main/java/com/example/mealapp/ui/MealAddFragment.kt
@@ -1,0 +1,20 @@
+package com.example.mealapp.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+/**
+ * Placeholder Fragment entspricht MealAdd.qml
+ */
+class MealAddFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_mealadd, container, false)
+    }
+}

--- a/android_native/app/src/main/java/com/example/mealapp/ui/MealOverviewFragment.kt
+++ b/android_native/app/src/main/java/com/example/mealapp/ui/MealOverviewFragment.kt
@@ -1,0 +1,20 @@
+package com.example.mealapp.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+/**
+ * Placeholder Fragment entspricht MealOverview.qml
+ */
+class MealOverviewFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_mealoverview, container, false)
+    }
+}

--- a/android_native/app/src/main/java/com/example/mealapp/ui/ShoppingListFragment.kt
+++ b/android_native/app/src/main/java/com/example/mealapp/ui/ShoppingListFragment.kt
@@ -1,0 +1,20 @@
+package com.example.mealapp.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+/**
+ * Placeholder Fragment entspricht ShoppingList.qml
+ */
+class ShoppingListFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_shoppinglist, container, false)
+    }
+}

--- a/android_native/app/src/main/java/com/example/mealapp/ui/WeekViewFragment.kt
+++ b/android_native/app/src/main/java/com/example/mealapp/ui/WeekViewFragment.kt
@@ -1,0 +1,20 @@
+package com.example.mealapp.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+/**
+ * Placeholder Fragment entspricht WeekView.qml
+ */
+class WeekViewFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_weekview, container, false)
+    }
+}

--- a/android_native/app/src/main/res/layout/activity_main.xml
+++ b/android_native/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- Container für Jetpack Navigation, entspricht SwipeView aus main.qml -->
+    <fragment
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:navGraph="@navigation/nav_graph" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android_native/app/src/main/res/layout/fragment_homepage.xml
+++ b/android_native/app/src/main/res/layout/fragment_homepage.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <!-- Layout übersetzt von HomePage.qml -->
+</FrameLayout>

--- a/android_native/app/src/main/res/layout/fragment_mealadd.xml
+++ b/android_native/app/src/main/res/layout/fragment_mealadd.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <!-- Layout übersetzt von MealAdd.qml -->
+</FrameLayout>

--- a/android_native/app/src/main/res/layout/fragment_mealoverview.xml
+++ b/android_native/app/src/main/res/layout/fragment_mealoverview.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <!-- Layout übersetzt von MealOverview.qml -->
+</FrameLayout>

--- a/android_native/app/src/main/res/layout/fragment_shoppinglist.xml
+++ b/android_native/app/src/main/res/layout/fragment_shoppinglist.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <!-- Layout übersetzt von ShoppingList.qml -->
+</FrameLayout>

--- a/android_native/app/src/main/res/layout/fragment_weekview.xml
+++ b/android_native/app/src/main/res/layout/fragment_weekview.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <!-- Layout übersetzt von WeekView.qml -->
+</FrameLayout>

--- a/android_native/app/src/main/res/navigation/nav_graph.xml
+++ b/android_native/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:startDestination="@id/homePageFragment">
+
+    <!-- Navigation Knoten entsprechen den QML Seiten -->
+    <fragment
+        android:id="@+id/homePageFragment"
+        android:name="com.example.mealapp.ui.HomePageFragment"
+        android:label="Home" />
+    <fragment
+        android:id="@+id/weekViewFragment"
+        android:name="com.example.mealapp.ui.WeekViewFragment"
+        android:label="Week" />
+    <fragment
+        android:id="@+id/mealAddFragment"
+        android:name="com.example.mealapp.ui.MealAddFragment"
+        android:label="Add" />
+    <fragment
+        android:id="@+id/mealOverviewFragment"
+        android:name="com.example.mealapp.ui.MealOverviewFragment"
+        android:label="Overview" />
+    <fragment
+        android:id="@+id/shoppingListFragment"
+        android:name="com.example.mealapp.ui.ShoppingListFragment"
+        android:label="Shopping" />
+</navigation>

--- a/android_native/app/src/main/res/values/strings.xml
+++ b/android_native/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MealApp</string>
+</resources>

--- a/android_native/app/src/main/res/values/themes.xml
+++ b/android_native/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.MealApp" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Farben können aus QML-Farben übernommen werden -->
+    </style>
+</resources>

--- a/android_native/build.gradle
+++ b/android_native/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android_native/settings.gradle
+++ b/android_native/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'MealApp'
+include ':app'


### PR DESCRIPTION
## Summary
- set up `android_native` skeleton project
- add Kotlin `MainActivity` and placeholder fragments for QML components
- stub layouts and navigation graph using Android XML
- supply Gradle build files and manifest

## Testing
- `./gradlew --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687145674f8483309645e0eee58e0f18