### PR TITLE
Improve WeekView item handling

### DIFF
--- a/meallistmodel.cpp
+++ b/meallistmodel.cpp
@@ -18,7 +18,6 @@ int MealListModel::rowCount(const QModelIndex &parent) const
     if (parent.isValid() || !mList)
         return 0;
 
-    // FIXME: Implement me!
     return mList->items().size();
 }
 
@@ -84,7 +83,7 @@ Qt::ItemFlags MealListModel::flags(const QModelIndex &index) const
     if (!index.isValid())
         return Qt::NoItemFlags;
 
-    return Qt::ItemIsEditable; // FIXME: Implement me!
+    return QAbstractListModel::flags(index) | Qt::ItemIsEditable;
 }
 
 QHash<int, QByteArray> MealListModel::roleNames() const

--- a/shoppinglistmodel.cpp
+++ b/shoppinglistmodel.cpp
@@ -21,7 +21,6 @@ int ShoppingListModel::rowCount(const QModelIndex &parent) const
     if (parent.isValid() || !mList)
         return 0;
 
-    // FIXME: Implement me!
     return mList->items().size();
 }
 
@@ -89,7 +88,7 @@ Qt::ItemFlags ShoppingListModel::flags(const QModelIndex &index) const
     if (!index.isValid())
         return Qt::NoItemFlags;
 
-    return Qt::ItemIsEditable; // FIXME: Implement me!
+    return QAbstractListModel::flags(index) | Qt::ItemIsEditable;
 }
 
 QHash<int, QByteArray> ShoppingListModel::roleNames() const

--- a/weekviewitem.cpp
+++ b/weekviewitem.cpp
@@ -14,6 +14,12 @@ WeekViewItem::WeekViewItem(MealItem *item, QObject *parent) : QObject(parent)
     setMealItem(item);
 }
 
+WeekViewItem::~WeekViewItem()
+{
+    if (mItem)
+        mItem->disconnect(this);
+}
+
 void WeekViewItem::setMealItem(MealItem *item, int persCount)
 {
     mItem = item;
@@ -112,6 +118,11 @@ int WeekViewItem::persCount() const
 {
     return mPersonCount;
 }
+
+int WeekViewItem::personCount() const
+{
+    return persCount();
+}
 void WeekViewItem::setPersCount(int count)
 {
     if (mPersonCount != count) {
@@ -119,6 +130,11 @@ void WeekViewItem::setPersCount(int count)
         emit personCountChanged(count);
         emit dataChanged();
     }
+}
+
+void WeekViewItem::setPersonCount(int count)
+{
+    setPersCount(count);
 }
 
 int WeekViewItem::picRotation() const

--- a/weekviewitem.h
+++ b/weekviewitem.h
@@ -21,6 +21,7 @@ class WeekViewItem : public QObject
 
 public:
     explicit WeekViewItem(MealItem *item, QObject *parent = nullptr);
+    ~WeekViewItem();
 
     int personCount() const;
     void setPersonCount(int count);


### PR DESCRIPTION
## Summary
- add destructor for `WeekViewItem`
- expose `personCount` wrappers
- return editable flag correctly in list models

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68714ee4c0508330b89da366bc506013